### PR TITLE
run deploy:migrate before deploy:finalize

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -9,6 +9,6 @@ namespace :deploy do
     end
   end
 
-  after 'deploy:update', 'deploy:migrate'
+  before 'deploy:finalize', 'deploy:migrate'
 end
 


### PR DESCRIPTION
As discussed in capistrano/capistrano#536, the patch will ensure `deploy:migrate` runs after `deploy:bundle`.

Note: this patch should be applied together with PR capistrano/capistrano#540 
