### PR TITLE
run deploy:migrate after deploy:update, to avoid it from running during deploy:rollback

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -9,6 +9,6 @@ namespace :deploy do
     end
   end
 
-  before 'deploy:finalize', 'deploy:migrate'
+  after 'deploy:update', 'deploy:migrate'
 end
 


### PR DESCRIPTION
This patch moves `deploy:migrate` to `deploy:update` hook, to prevent `deploy:rollback` from running `deploy:migrate`. 

This is a _temporary workaround_. 

It will create another issue, i.e. the ordering of require statements in Capfile will now become significant. It's because `deploy:bundle` is added to the same `deploy:update` hook too, however, it must run before `deploy:migrate`:

```
# Capfile
require 'capistrano/bundler'     # must appear before rails/migrations
require 'capistrano/rails/migrations'
require 'capistrano/rails/assets'
```

```
# task run flow
deploy:update
  git:create_release
  deploy:symlink:shared
    deploy:symlink:linked_files
    deploy:symlink:linked_dirs
  _after:
    deploy:bundle   # must run first
    deploy:migrate
```

To better resolve the issue, I propose to introduce a new hook ie. `deploy:finalize_update`:

```
# task run flow
deploy:update
  git:create_release
  deploy:symlink:shared
    deploy:symlink:linked_files
    deploy:symlink:linked_dirs

deploy:finalize_update
  _before:              # preparation before custom update e.g. install gems
    deploy:bundle
  _after:               # custom update tasks e.g. migration, assets precompile etc.
    deploy:migrate
```
