### PR TITLE
Using `bundle exec rake` instead of `rake`

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -29,7 +29,7 @@ namespace :deploy do
     on roles :web do
       within release_path do
         with rails_env: fetch(:stage) do
-          execute :rake, "assets:clean"
+          execute :bundle, "exec rake assets:clean"
         end
       end
     end
@@ -54,7 +54,7 @@ namespace :deploy do
       on roles :web do
         within release_path do
           with rails_env: fetch(:stage) do
-            execute :rake, "assets:precompile"
+            execute :bundle, "exec rake assets:precompile"
           end
         end
       end

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -5,7 +5,7 @@ namespace :deploy do
     on primary :db do
       within release_path do
         with rails_env: fetch(:stage) do
-          execute :rake, "db:migrate"
+          execute :bundle, "exec rake db:migrate"
         end
       end
     end


### PR DESCRIPTION
Otherwise conflict of Rake versions is possible:

```
 INFO [7c96ac77] Running rake assets:precompile on 37.139.8.xxx
DEBUG [7c96ac77] Command: cd /home/deploy/navigator/releases/20130805155434 && ( RAILS_ENV=production rake assets:precompile )
DEBUG [7c96ac77]    rake aborted!
DEBUG [7c96ac77]    You have already activated rake 0.9.6, but your Gemfile requires rake 10.1.0. Using bundle exec may solve this.
DEBUG [7c96ac77]    /home/deploy/navigator/releases/20130805155434/config/boot.rb:4:in `<top (required)>'
DEBUG [7c96ac77]    /home/deploy/navigator/releases/20130805155434/config/application.rb:1:in `<top (required)>'
DEBUG [7c96ac77]    /home/deploy/navigator/releases/20130805155434/Rakefile:4:in `<top (required)>'
DEBUG [7c96ac77]    (See full trace by running task with --trace)
```

I could also override `:rake` in `SSHKit.config.command_map`, but it's been already used to rbenv integration.
