### PR TITLE
Don't normalise assets by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Rails specific tasks for Capistrano v3:
 
 Assumes that `RAILS_ENV` matches stage, tasks are currently early examples
 
+If you need to touch `public/images`, `public/javascripts` and `public/stylesheets` on each deploy:
+
+```ruby
+set :normalize_asset_timestamps, %{public/images public/javascripts public/stylesheets}
+```
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -11,9 +11,11 @@ namespace :deploy do
   desc 'Normalise asset timestamps'
   task :normalise_assets do
     on roles :web do
-      within release_path do
-        assets = %{public/images public/javascripts public/stylesheets}
-        execute :find, "#{assets} -exec touch -t #{asset_timestamp} {} ';'; true"
+      assets = fetch(:normalize_asset_timestamps)
+      if assets
+        within release_path do
+          execute :find, "#{assets} -exec touch -t #{asset_timestamp} {} ';'; true"
+        end
       end
     end
   end


### PR DESCRIPTION
I think we need to return `normalize_asset_timestamps` option from Capistrano 2.x (https://github.com/capistrano/capistrano/blob/1fd63128120115657acec102fec573ca9d9e88e8/lib/capistrano/recipes/deploy.rb#L293), but it should be **disabled** by default (this operation is not necessary at all for Rails >= 3.1).

Otherwise (as `public/javascripts`, `public/stylesheets`, `public/images` doesn't exist in basic Rails >= 3.1 app) it generates some ugly warnings:

```
 INFO [d39e3799] Running find public/images public/javascripts public/stylesheets -exec touch -t 201308052135.27 {} ';'; true on 37.139.8.xxx
DEBUG [d39e3799] Command: cd /home/deploy/navigator/releases/20130805213527 && find public/images public/javascripts public/stylesheets -exec touch -t 201308052135.27 {} ';'; true
DEBUG [d39e3799]  find:
DEBUG [d39e3799]  `public/images'
DEBUG [d39e3799]  : No such file or directory
DEBUG [d39e3799]
DEBUG [d39e3799]  find:
DEBUG [d39e3799]  `public/javascripts'
DEBUG [d39e3799]  : No such file or directory
DEBUG [d39e3799]
DEBUG [d39e3799]  find:
DEBUG [d39e3799]  `public/stylesheets'
DEBUG [d39e3799]  : No such file or directory
DEBUG [d39e3799]
 INFO [d39e3799] Finished in 0.143 seconds command successful.
```
