### PR TITLE
Making sure we can also work with manifest.yml files

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -69,7 +69,7 @@ namespace :deploy do
         within release_path do
           execute :cp,
             release_path.join('public', 'assets', 'manifest*'),
-            release_path.join('assets_manifest_backup.json')
+            release_path.join('assets_manifest_backup')
         end
       end
     end
@@ -77,7 +77,7 @@ namespace :deploy do
     task :restore_manifest do
       on roles :web do
         within release_path do
-          source = release_path.join('assets_manifest_backup.json')
+          source = release_path.join('assets_manifest_backup')
           target = capture(:ls, release_path.join('public', 'assets',
                                                   'manifest*')).strip
           if test "[[ -f #{source} && -f #{target} ]]"


### PR DESCRIPTION
Instead of searching for a `manifest*.json` file explicitly, we can just search for a `manifest*` file (as done in the restore task).
