### PR TITLE
put wildcard in asset path

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -68,7 +68,7 @@ namespace :deploy do
       on roles :web do
         within release_path do
           execute :cp,
-            release_path.join('public', 'assets', 'manifest*'),
+            release_path.join('public', 'assets', '**', 'manifest*'),
             release_path.join('assets_manifest_backup')
         end
       end


### PR DESCRIPTION
I had a problem where `rake assets:precompile` would put the manifest in public/assets/#{application}/manifest**.json

I dont see a configuration we set to do this but we are using a gem to upload our assets to a CDS that might be doing this.  Because this might be something a library does and could potentially use the name name of the library, the application, or both. I thought a *\* would cover all those cases.
