### PR TITLE
using special execute for bundled gems

### DIFF
--- a/lib/capistrano/rails.rb
+++ b/lib/capistrano/rails.rb
@@ -1,3 +1,15 @@
+def use_bundler?
+  Gem::Specification::find_all_by_name('capistrano-bundler').any?
+end
+
+def execute_bundled(command, *args)
+  if use_bundler?
+    execute :bundle, "exec", command.to_s, args
+  else
+    execute command, args
+  end
+end
+
 load File.expand_path("../tasks/rails.rake", __FILE__)
 
 require 'capistrano/rails/assets'

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -32,7 +32,7 @@ namespace :deploy do
     on roles :web do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "assets:clean"
+          execute_bundled :rake, "assets:clean"
         end
       end
     end
@@ -58,7 +58,7 @@ namespace :deploy do
       on roles :web do
         within release_path do
           with rails_env: fetch(:rails_env) do
-            execute :rake, "assets:precompile"
+            execute_bundled :rake, "assets:precompile"
           end
         end
       end

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -1,11 +1,10 @@
 namespace :deploy do
-
   desc 'Runs rake db:migrate if migrations are set'
   task :migrate do
     on primary fetch(:migration_role) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "db:migrate"
+          execute_bundled :rake, "db:migrate"
         end
       end
     end


### PR DESCRIPTION
proposing this way of solving the rails-bundler-command problem.
Just a proposal, no tests or further thoughts spent.

We should make sure that every future gem working with capistrano using a bundled gem is using the `execute_bundled` command. Maybe the method is suited better somewhere else.
Could solve at least the most easiest interaction for Rails deployments.

This way, if we use bundler, the rake-command is called through the `bundle exec`.
`bundle` on the other hand is called via RVM/rbenv after that with the command_map of SSHKit.

In my opinion the special bundler support should be removed from the rbenv gem. Just handle the case if bundler-gem is loaded, the pass the `bundle` call through rbenv, nothing more (like the RVM gem currently does).
