### PR TITLE
Set rails_env if parts of capistrano-rails are required

### DIFF
--- a/lib/capistrano/rails.rb
+++ b/lib/capistrano/rails.rb
@@ -1,4 +1,2 @@
-load File.expand_path("../tasks/rails.rake", __FILE__)
-
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,3 +1,5 @@
+load File.expand_path("../set_rails_env.rake", __FILE__)
+
 module Capistrano
   class FileNotFound < StandardError
   end
@@ -9,7 +11,7 @@ namespace :deploy do
   end
 
   desc 'Normalise asset timestamps'
-  task :normalise_assets do
+  task :normalise_assets => [:set_rails_env] do
     on roles :web do
       assets = fetch(:normalize_asset_timestamps)
       if assets
@@ -21,7 +23,7 @@ namespace :deploy do
   end
 
   desc 'Compile assets'
-  task :compile_assets do
+  task :compile_assets => [:set_rails_env] do
     invoke 'deploy:assets:precompile'
     invoke 'deploy:assets:backup_manifest'
   end
@@ -39,7 +41,7 @@ namespace :deploy do
   end
 
   desc 'Rollback assets'
-  task :rollback_assets do
+  task :rollback_assets => [:set_rails_env] do
     begin
       invoke 'deploy:assets:restore_manifest'
     rescue Capistrano::FileNotFound

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -1,7 +1,9 @@
+load File.expand_path("../set_rails_env.rake", __FILE__)
+
 namespace :deploy do
 
   desc 'Runs rake db:migrate if migrations are set'
-  task :migrate do
+  task :migrate => [:set_rails_env] do
     on primary fetch(:migration_role) do
       within release_path do
         with rails_env: fetch(:rails_env) do

--- a/lib/capistrano/tasks/set_rails_env.rake
+++ b/lib/capistrano/tasks/set_rails_env.rake
@@ -1,5 +1,5 @@
 namespace :deploy do
-  before :starting, :set_rails_env do
+  task :set_rails_env do
     set :rails_env, (fetch(:rails_env) || fetch(:stage))
   end
 end


### PR DESCRIPTION
Previously, `rails_env` was set only when `capistrano/rails` was required.
That caused issues when developers required only `capistrano/rails/assets` or migrations. Fixes https://github.com/capistrano/capistrano/pull/699 and https://github.com/capistrano/capistrano/issues/724

/cc @leehambley
