### PR TITLE
Restrict dependency on capistrano to ~> 3.0.0

### DIFF
--- a/capistrano-rails.gemspec
+++ b/capistrano-rails.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'capistrano'
+  gem.add_dependency 'capistrano', '~> 3.0.0'
 
 end


### PR DESCRIPTION
As per capistrano/capistrano#742
