### PR TITLE
execute_rake is defined

### DIFF
--- a/lib/capistrano/rails/assets.rb
+++ b/lib/capistrano/rails/assets.rb
@@ -1,1 +1,3 @@
+require File.expand_path("../execute_rake", __FILE__)
+
 load File.expand_path("../../tasks/assets.rake", __FILE__)

--- a/lib/capistrano/rails/execute_rake.rb
+++ b/lib/capistrano/rails/execute_rake.rb
@@ -1,0 +1,5 @@
+class SSHKit::Backend::Netssh
+  def execute_rake(*args)
+    execute(fetch(:rake) || :rake, *args)
+  end
+end

--- a/lib/capistrano/rails/migrations.rb
+++ b/lib/capistrano/rails/migrations.rb
@@ -1,1 +1,3 @@
+require File.expand_path("../execute_rake", __FILE__)
+
 load File.expand_path("../../tasks/migrations.rake", __FILE__)


### PR DESCRIPTION
'execute :rake, *' is not flexible because we want to execute rake in some other forms: 'bundle exec rake', './bin/rake'.
execute_rake fix this by making enable users set :rake 'some rake'.
