### PR TITLE
Add `assets_roles` and `assets_prefix` options for asset customisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Rails specific tasks for Capistrano v3:
 Some rails specific options.
 
 ```ruby
-set :rails_env, 'staging'       # If the environment differs from the stage name
-set :migration_role, 'migrator' # Defaults to 'db'
+set :rails_env, 'staging'                  # If the environment differs from the stage name
+set :migration_role, 'migrator'            # Defaults to 'db'
+set :assets_roles, [:web, :app]            # Defaults to [:web]
+set :assets_prefix, 'prepackaged-assets'   # Defaults to 'assets' this should match config.assets.prefix in your rails config/application.rb
 ```
 
 If you need to touch `public/images`, `public/javascripts` and `public/stylesheets` on each deploy:

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -6,13 +6,9 @@ module Capistrano
 end
 
 namespace :deploy do
-  before :starting, :set_shared_assets do
-    set :linked_dirs, (fetch(:linked_dirs) || []).push('public/assets')
-  end
-
   desc 'Normalise asset timestamps'
   task :normalise_assets => [:set_rails_env] do
-    on roles :web do
+    on roles(fetch(:assets_roles)) do
       assets = fetch(:normalize_asset_timestamps)
       if assets
         within release_path do
@@ -31,7 +27,7 @@ namespace :deploy do
   # FIXME: it removes every asset it has just compiled
   desc 'Cleanup expired assets'
   task :cleanup_assets => [:set_rails_env] do
-    on roles :web do
+    on roles(fetch(:assets_roles)) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, "assets:clean"
@@ -57,7 +53,7 @@ namespace :deploy do
 
   namespace :assets do
     task :precompile do
-      on roles :web do
+      on roles(fetch(:assets_roles)) do
         within release_path do
           with rails_env: fetch(:rails_env) do
             execute :rake, "assets:precompile"
@@ -67,20 +63,20 @@ namespace :deploy do
     end
 
     task :backup_manifest do
-      on roles :web do
+      on roles(fetch(:assets_roles)) do
         within release_path do
           execute :cp,
-            release_path.join('public', 'assets', 'manifest*'),
+            release_path.join('public', fetch(:assets_prefix), 'manifest*'),
             release_path.join('assets_manifest_backup')
         end
       end
     end
 
     task :restore_manifest do
-      on roles :web do
+      on roles(fetch(:assets_roles)) do
         within release_path do
           source = release_path.join('assets_manifest_backup')
-          target = capture(:ls, release_path.join('public', 'assets',
+          target = capture(:ls, release_path.join('public', fetch(:assets_prefix),
                                                   'manifest*')).strip
           if test "[[ -f #{source} && -f #{target} ]]"
             execute :cp, source, target
@@ -94,5 +90,12 @@ namespace :deploy do
     end
 
   end
+end
 
+namespace :load do
+  task :defaults do
+    set :assets_roles, [:web]
+    set :assets_prefix, 'assets'
+    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
+  end
 end


### PR DESCRIPTION
We need to precompile assets into both the web and app roles due to how our infrastructure is split up, this allows previous behaviour to be maintained but can be overridden when needed.

Whilst doing this I also noticed that the rails asset prefix was assumed to be "assets", again this fixes this and leaves "assets" as the default so as not to break any previous behaviour.
