### PR TITLE
Fix asset backup file

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -71,7 +71,7 @@ namespace :deploy do
         within release_path do
           execute :cp,
             release_path.join('public', 'assets', 'manifest*'),
-            release_path.join('assets_manifest_backup')
+            release_path.join('assets_manifest.backup')
         end
       end
     end
@@ -79,7 +79,7 @@ namespace :deploy do
     task :restore_manifest do
       on roles :web do
         within release_path do
-          source = release_path.join('assets_manifest_backup')
+          source = release_path.join('assets_manifest.backup')
           target = capture(:ls, release_path.join('public', 'assets',
                                                   'manifest*')).strip
           if test "[[ -f #{source} && -f #{target} ]]"


### PR DESCRIPTION
Commit bfd01c9 removed the .json suffix from the assets_manifest_backup. This produces an error when deploying on my Ubuntu environment. Suggest changing assets_manifest_backup to assets_manifest.backup

```
DEBUG [7813d7de] Command: cd /home/deployer/discourse-production/releases/20131115183147 && ( RAILS_ENV=production cp /home/deployer/discourse-production/releases/20131115183147/public/assets/manifest* /home/deployer/discourse-production/releases/20131115183147/assets_manifest_backup )
DEBUG [7813d7de]    cp: 
DEBUG [7813d7de]    target `/home/deployer/discourse-production/releases/20131115183147/assets_manifest_backup' is not a directory
```
