### PR TITLE
Added rails command to command map to use bundle

### DIFF
--- a/lib/capistrano/rails.rb
+++ b/lib/capistrano/rails.rb
@@ -1,3 +1,5 @@
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+
+SSHKit.config.command_map.prefix[:rails].push('bundle exec')


### PR DESCRIPTION
Sometime I need to run `rails` command example to run interactive console. And found that this gem required `capistrano-bundler` and used it for execute `rake`.

Added this map will not harm.

I am not sure about right place for map bins.
