### PR TITLE
Add db:create command into migrate task and db_create option.

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -19,7 +19,7 @@ end
 
 namespace :load do
   task :defaults do
-    set db_create, fetch(:db_create, false)
+    set :db_create, fetch(:db_create, false)
     set :migration_role, fetch(:migration_role, :db)
   end
 end


### PR DESCRIPTION
Hi, 
when I tried to deploy my Rails app to the bare server, without pre-created app's db, I receive the error that db isn't exists on db:migrate execution.  So, I added "db:create" for this error avoiding.
