### PR TITLE
normalize spelling of task names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# future release
+
+* normalized spelling
+  * 'deploy:normalise_assets' is now 'deploy:normalize_assets'
+
 # 1.1.1
 
 * New `asset_roles` options: https://github.com/capistrano/rails/pull/30

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -6,8 +6,8 @@ module Capistrano
 end
 
 namespace :deploy do
-  desc 'Normalise asset timestamps'
-  task :normalise_assets => [:set_rails_env] do
+  desc 'Normalize asset timestamps'
+  task :normalize_assets => [:set_rails_env] do
     on roles(fetch(:assets_roles)) do
       assets = fetch(:normalize_asset_timestamps)
       if assets
@@ -48,7 +48,7 @@ namespace :deploy do
   after 'deploy:updated', 'deploy:compile_assets'
   # NOTE: we don't want to remove assets we've just compiled
   # after 'deploy:updated', 'deploy:cleanup_assets'
-  after 'deploy:updated', 'deploy:normalise_assets'
+  after 'deploy:updated', 'deploy:normalize_assets'
   after 'deploy:reverted', 'deploy:rollback_assets'
 
   namespace :assets do


### PR DESCRIPTION
closes #26

for previous discussion see #26
- sticking to the 'z' spelling like Rails does
- changelog entry added, mentioning the task rename
