### PR TITLE
update README sample Gemfile to match gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ set :normalize_asset_timestamps, %{public/images public/javascripts public/style
 
 Add this line to your application's Gemfile:
 
-    gem 'capistrano',  '~> 3.0.0'
-    gem 'capistrano-rails', '~> 1.1.0'
+    gem 'capistrano',  '~> 3.1'
+    gem 'capistrano-rails', '~> 1.1'
 
 ## Usage
 


### PR DESCRIPTION
Advise people to use less restrictive version selectors in their Gemfile.
This also matches now the versions defined in the current gemspec.
