### PR TITLE
Add RAILS_GROUPS env variable for assets compilation

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -55,7 +55,7 @@ namespace :deploy do
     task :precompile do
       on roles(fetch(:assets_roles)) do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          with rails_env: fetch(:rails_env), rails_groups: 'assets' do
             execute :rake, "assets:precompile"
           end
         end


### PR DESCRIPTION
Maybe I'm just missing something but assets failed to compile for my Rails 3.2 app until I added the `RAILS_GROUPS` variable. I discovered it by comparing with the command capistrano v2 has been using. Can anyone confirm or refute this issue on Rails 3.2?
