### PR TITLE
narrow down globbing for manifest json in {backup,restore}_manifest

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -66,7 +66,7 @@ namespace :deploy do
       on roles(fetch(:assets_roles)) do
         within release_path do
           execute :cp,
-            release_path.join('public', fetch(:assets_prefix), 'manifest*'),
+            release_path.join('public', fetch(:assets_prefix), 'manifest-*.json'),
             release_path.join('assets_manifest_backup')
         end
       end
@@ -77,7 +77,7 @@ namespace :deploy do
         within release_path do
           source = release_path.join('assets_manifest_backup')
           target = capture(:ls, release_path.join('public', fetch(:assets_prefix),
-                                                  'manifest*')).strip
+                                                  'manifest-*.json')).strip
           if test "[[ -f #{source} && -f #{target} ]]"
             execute :cp, source, target
           else


### PR DESCRIPTION
The cp for backing up the manifest file fails when there are manifests (as in "products of the pipeline compilation", to distinguish it from the json summary file) that start with "manifest" in their relative name.

(I have a case here where I like to have manifest assets in a manifests directory to avoid collision)
