### PR TITLE
Added deploy:set_rails_env to run after invoking stage

### DIFF
--- a/lib/capistrano/tasks/set_rails_env.rake
+++ b/lib/capistrano/tasks/set_rails_env.rake
@@ -3,3 +3,7 @@ namespace :deploy do
     set :rails_env, (fetch(:rails_env) || fetch(:stage))
   end
 end
+
+Capistrano::DSL.stages.each do |stage|
+  after stage, 'deploy:set_rails_env'
+end


### PR DESCRIPTION
Hello! 

What about setting RAILS_ENV before all tasks after invoking stage?

``` ruby
Capistrano::DSL.stages.each do |stage|
  after stage, 'deploy:set_rails_env'
end
```

It'l be useful in other gems using RAILS_ENV for transparent support, ex. capistrano3-rails etc.
