### PR TITLE
Separate hooks into a new file that doesn't need to be required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ Or require just what you need manually:
     require 'capistrano/bundler' # Rails needs Bundler, right?
     require 'capistrano/rails/assets'
     require 'capistrano/rails/migrations'
-    
+    require 'capistrano/rails/hooks'
+
 Please note that any `require` should be placed in `Capfile`, not `config/deploy.rb`.
 
 ## Contributing

--- a/lib/capistrano/rails.rb
+++ b/lib/capistrano/rails.rb
@@ -1,3 +1,4 @@
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+require 'capistrano/rails/hooks'

--- a/lib/capistrano/rails/hooks.rb
+++ b/lib/capistrano/rails/hooks.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../../tasks/hooks.rake", __FILE__)

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -45,12 +45,6 @@ namespace :deploy do
     end
   end
 
-  after 'deploy:updated', 'deploy:compile_assets'
-  # NOTE: we don't want to remove assets we've just compiled
-  # after 'deploy:updated', 'deploy:cleanup_assets'
-  after 'deploy:updated', 'deploy:normalize_assets'
-  after 'deploy:reverted', 'deploy:rollback_assets'
-
   namespace :assets do
     task :precompile do
       on roles(fetch(:assets_roles)) do

--- a/lib/capistrano/tasks/hooks.rake
+++ b/lib/capistrano/tasks/hooks.rake
@@ -1,0 +1,5 @@
+after 'deploy:updated', 'deploy:compile_assets'
+after 'deploy:updated', 'deploy:normalize_assets'
+after 'deploy:reverted', 'deploy:rollback_assets'
+
+after 'deploy:updated', 'deploy:migrate'

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -1,7 +1,6 @@
 load File.expand_path("../set_rails_env.rake", __FILE__)
 
 namespace :deploy do
-
   desc 'Runs rake db:migrate if migrations are set'
   task :migrate => [:set_rails_env] do
     on primary fetch(:migration_role) do
@@ -12,8 +11,6 @@ namespace :deploy do
       end
     end
   end
-
-  after 'deploy:updated', 'deploy:migrate'
 end
 
 namespace :load do


### PR DESCRIPTION
This change separates the "hooks" into a new file. The default use case doesn't change (when you require the whole thing), but it allows you to require assets, migrations and hooks separately (or in my case, use my own hooks).

Let me know what you think.