### PR TITLE
Allow early overriding of assets_* parameters

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -94,8 +94,8 @@ end
 
 namespace :load do
   task :defaults do
-    set :assets_roles, [:web]
-    set :assets_prefix, 'assets'
+    set :assets_roles, fetch(:assets_roles, [:web])
+    set :assets_prefix, fetch(:assets_prefix, 'assets')
     set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
   end
 end


### PR DESCRIPTION
Because the `load:defaults` task didn't check whether `assets_roles` or `assets_prefix` had already been set, the default settings could only be overridden from `deploy.rb` or `a_stage.rb`, but not from `Capfile`. However, styles differ and keeping the relevant settings close to the appropriate `require` is possible with this change, while it has no downsides afaik.
