### PR TITLE
Cut down assets precompilation by symlinking cache

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -96,6 +96,6 @@ namespace :load do
   task :defaults do
     set :assets_roles, [:web]
     set :assets_prefix, 'assets'
-    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
+    set :linked_dirs, fetch(:linked_dirs, []) << "public/#{fetch(:assets_prefix)}" << "tmp/cache"
   end
 end


### PR DESCRIPTION
If you have large amounts of assets in your pipeline, default Capistrano task will not re-use cache, effectively making precompilation of assets take minutes vs. seconds if cache was used. This fixes the issue.
