### PR TITLE
Moving assets_manifest_backup to tmp directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fixed no_release behaviour (https://github.com/capistrano/rails/pull/95)
 * Allow assets manifest backup with folder "manifests" (https://github.com/capistrano/rails/pull/92)
+* Manifest backups moved to tmp/capistrano_assets_backup
 
 # 1.1.2 (Sep 1 2014)
 

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -67,7 +67,7 @@ namespace :deploy do
         within release_path do
           execute :cp,
             release_path.join('public', fetch(:assets_prefix), 'manifest*'),
-            release_path.join('assets_manifest_backup')
+            release_path.join('tmp', 'assets_manifest_backup')
         end
       end
     end
@@ -75,7 +75,7 @@ namespace :deploy do
     task :restore_manifest do
       on roles(fetch(:assets_roles)) do
         within release_path do
-          source = release_path.join('assets_manifest_backup')
+          source = release_path.join('tmp', 'assets_manifest_backup')
           target = capture(:ls, release_path.join('public', fetch(:assets_prefix),
                                                   'manifest*')).strip
           if test "[[ -f #{source} && -f #{target} ]]"

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -65,7 +65,7 @@ namespace :deploy do
     task :backup_manifest do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
-          execute :mkdir, release_path.join('tmp', 'capistrano_assets_backup')
+          execute :mkdir, '-p', release_path.join('tmp', 'capistrano_assets_backup')
           execute :cp,
             release_path.join('public', fetch(:assets_prefix), 'manifest*'),
             release_path.join('tmp', 'capistrano_assets_backup')

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -78,8 +78,12 @@ namespace :deploy do
         within release_path do
           source = release_path.join('tmp', 'capistrano_assets_backup', 'manifest*')
           target = release_path.join('public', fetch(:assets_prefix))
+          manifests = capture(:ls, release_path.join('public', fetch(:assets_prefix), 'manifest*')).split
 
           execute :cp, source, target
+          manifests.each do |manifest|
+            info "#{manifest.split('/').last} restored."
+          end
         end
       end
     end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -65,10 +65,10 @@ namespace :deploy do
     task :backup_manifest do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
-          execute :mkdir, release_path.join('tmp', 'capistrano_backup')
+          execute :mkdir, release_path.join('tmp', 'capistrano_assets_backup')
           execute :cp,
             release_path.join('public', fetch(:assets_prefix), 'manifest*'),
-            release_path.join('tmp', 'capistrano_backup')
+            release_path.join('tmp', 'capistrano_assets_backup')
         end
       end
     end
@@ -76,7 +76,7 @@ namespace :deploy do
     task :restore_manifest do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
-          source = release_path.join('tmp', 'capistrano_backup', 'manifest*')
+          source = release_path.join('tmp', 'capistrano_assets_backup', 'manifest*')
           target = release_path.join('public', fetch(:assets_prefix))
 
           execute :cp, source, target


### PR DESCRIPTION
I use two roles to deploy my application: one (without rvm) to pulling from git, another (with rvm) to compiling assets and migrating database schema. User who execute deploy:compile_assets have no access to write to application root directory, I think, it's good idea move backup manifest file from root directory to tmp subdirectory.