### PR TITLE
Bring back custom migrate environment variable

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -13,7 +13,8 @@ namespace :deploy do
         info '[deploy:migrate] Run `rake db:migrate`' if conditionally_migrate
         within release_path do
           with rails_env: fetch(:rails_env) do
-            execute :rake, "db:migrate"
+            migrate_env = fetch(:migrate_env, "")
+            execute :rake, "db:migrate #{migrate_env}"
           end
         end
       end


### PR DESCRIPTION
With Capistrano 2.X it was possible to define custom 
environment variables for the migration. This commit
brings back this feature.
https://github.com/capistrano/capistrano/blob/legacy-v2/lib/capistrano/recipes/deploy.rb#L438