### PR TITLE
Allow assets manifest backup with folder "manifests"

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -66,7 +66,7 @@ namespace :deploy do
       on roles(fetch(:assets_roles)) do
         within release_path do
           execute :cp,
-            release_path.join('public', fetch(:assets_prefix), 'manifest*'),
+            release_path.join('public', fetch(:assets_prefix), 'manifest.*'),
             release_path.join('assets_manifest_backup')
         end
       end


### PR DESCRIPTION
Matching all files named `manifest` with an extension (`yml`, `json`, …) but not folders starting with `manifest`

Fixes #91 
