### PR TITLE
Handle no_release properly

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -8,7 +8,7 @@ end
 namespace :deploy do
   desc 'Normalize asset timestamps'
   task :normalize_assets => [:set_rails_env] do
-    on roles(fetch(:assets_roles)) do
+    on release_roles(fetch(:assets_roles)) do
       assets = fetch(:normalize_asset_timestamps)
       if assets
         within release_path do
@@ -27,7 +27,7 @@ namespace :deploy do
   # FIXME: it removes every asset it has just compiled
   desc 'Cleanup expired assets'
   task :cleanup_assets => [:set_rails_env] do
-    on roles(fetch(:assets_roles)) do
+    on release_roles(fetch(:assets_roles)) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, "assets:clean"
@@ -53,7 +53,7 @@ namespace :deploy do
 
   namespace :assets do
     task :precompile do
-      on roles(fetch(:assets_roles)) do
+      on release_roles(fetch(:assets_roles)) do
         within release_path do
           with rails_env: fetch(:rails_env) do
             execute :rake, "assets:precompile"
@@ -63,7 +63,7 @@ namespace :deploy do
     end
 
     task :backup_manifest do
-      on roles(fetch(:assets_roles)) do
+      on release_roles(fetch(:assets_roles)) do
         within release_path do
           execute :cp,
             release_path.join('public', fetch(:assets_prefix), 'manifest*'),
@@ -73,7 +73,7 @@ namespace :deploy do
     end
 
     task :restore_manifest do
-      on roles(fetch(:assets_roles)) do
+      on release_roles(fetch(:assets_roles)) do
         within release_path do
           source = release_path.join('assets_manifest_backup')
           target = capture(:ls, release_path.join('public', fetch(:assets_prefix),


### PR DESCRIPTION
For our development and staging environment, we deploy all roles to the same machine. We prevent tasks from being run twice by marking all except the app role as `no_release`.

```
role :app, 'development.silp.com'
role :clock, 'clock.development.silp.com', :no_release => true
role :worker, 'worker.development.silp.com', :no_release => true
```

Both the :app and :worker need assets, so we define `assets_roles` as follows:

```
set :assets_roles, [:app, :worker]
```

In production, we just remove the `no_release` flag and all tasks get run on each server.

capistrano-rails/assets ignores the `no_release` flag and executes the task for all roles. This is unnecessary and also leads to duplicate manifest files which in turn let's the whole deployment fail with the infamous `...assets_manifest_backup’ is not a directory` error. Also see #33 and #91

This pr uses `on release_roles` instead of `on roles`
