### PR TITLE
Fix assets manifest path in assets manifest backup task

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -66,7 +66,7 @@ namespace :deploy do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
           execute :cp,
-            release_path.join('public', fetch(:assets_prefix), 'manifest.*'),
+            release_path.join('public', fetch(:assets_prefix), 'manifest*.*'),
             release_path.join('assets_manifest_backup')
         end
       end


### PR DESCRIPTION
Use wildcard before the dot extension separator to cover new Rails 4 manifest name using a dash and a digest number (e.g. `manifest-785927758943.json` and `manifest.yml` are covered).
