### PR TITLE
Ensure assets backup path is in place

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -65,9 +65,12 @@ namespace :deploy do
     task :backup_manifest do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
+          backup_path = release_path.join('assets_manifest_backup')
+
+          execute :mkdir, '-p', backup_path
           execute :cp,
             release_path.join('public', fetch(:assets_prefix), 'manifest*.*'),
-            release_path.join('assets_manifest_backup')
+            backup_path
         end
       end
     end


### PR DESCRIPTION
This fixes an otherwise failing capistrano task. Related to #33.