### PR TITLE
feat(migrations): skip migration when role doesn't include migration_role

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -4,16 +4,18 @@ namespace :deploy do
 
   desc 'Runs rake db:migrate if migrations are set'
   task :migrate => [:set_rails_env] do
-    on primary fetch(:migration_role) do
-      conditionally_migrate = fetch(:conditionally_migrate)
-      info '[deploy:migrate] Checking changes in /db/migrate' if conditionally_migrate
-      if conditionally_migrate && test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate")
-        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate)'
-      else
-        info '[deploy:migrate] Run `rake db:migrate`'
-        within release_path do
-          with rails_env: fetch(:rails_env) do
-            execute :rake, "db:migrate"
+    on roles fetch(:migration_role) do
+      on primary fetch(:migration_role) do
+        conditionally_migrate = fetch(:conditionally_migrate)
+        info '[deploy:migrate] Checking changes in /db/migrate' if conditionally_migrate
+        if conditionally_migrate && test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate")
+          info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate)'
+        else
+          info '[deploy:migrate] Run `rake db:migrate`'
+          within release_path do
+            with rails_env: fetch(:rails_env) do
+              execute :rake, "db:migrate"
+            end
           end
         end
       end


### PR DESCRIPTION
Sometimes, I want to deploy code to servers with specific role which don't require migration.