### PR TITLE
Rescue `SSHKit::Runner::ExecuteError` in rollback_assets

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -40,8 +40,12 @@ namespace :deploy do
   task :rollback_assets => [:set_rails_env] do
     begin
       invoke 'deploy:assets:restore_manifest'
-    rescue Capistrano::FileNotFound
-      invoke 'deploy:compile_assets'
+    rescue SSHKit::Runner::ExecuteError => e
+      if e.cause.is_a?(Capistrano::FileNotFound)
+        invoke 'deploy:compile_assets'
+      else
+        raise e
+      end
     end
   end
 


### PR DESCRIPTION
SSHKit wraps all exceptions in `SSHKit::Runner::ExecuteError` to print
the host where the exception occured. This exception must be rescued
instead of `Capistrano::FileNotFound` in rollback_assets task and
`deploy:compile_assets` is invoked if the cause is the correct
exception.