### PR TITLE
Fixed deployment failure when found more than one assets manifest file

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -97,7 +97,7 @@ namespace :deploy do
         manifest*.*
       ).each do |pattern|
         candidate = release_path.join('public', fetch(:assets_prefix), pattern)
-        return capture(:ls, candidate).strip if test(:ls, candidate)
+        return capture(:ls, candidate).strip.gsub("\n"," ") if test(:ls, candidate)
       end
       msg = 'Rails assets manifest file not found.'
       warn msg


### PR DESCRIPTION
"cp" command fails, because "ls" outputs each founded file on separate line.
