### PR TITLE
Issue 123: Remove newline characters from manifest list

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -97,7 +97,7 @@ namespace :deploy do
         manifest*.*
       ).each do |pattern|
         candidate = release_path.join('public', fetch(:assets_prefix), pattern)
-        return capture(:ls, candidate).strip if test(:ls, candidate)
+        return capture(:ls, candidate).gsub(/\s+/, ' ').strip if test(:ls, candidate)
       end
       msg = 'Rails assets manifest file not found.'
       warn msg


### PR DESCRIPTION
Addresses [Issue 123](https://github.com/capistrano/rails/issues/123), where having multiple manifest files will cause issues with other actions due to unstripped newline characters.