### PR TITLE
Fixed linked_dirs containing default value of assets_prefix, whereas the last one was changed

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -106,10 +106,19 @@ namespace :deploy do
   end
 end
 
+# we can't set linked_dirs in load:defaults,
+# as assets_prefix will always have a default value
+namespace :deploy do
+  task :set_linked_dirs do
+    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
+  end
+end
+
+after 'deploy:set_rails_env', 'deploy:set_linked_dirs'
+
 namespace :load do
   task :defaults do
     set :assets_roles, fetch(:assets_roles, [:web])
     set :assets_prefix, fetch(:assets_prefix, 'assets')
-    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
   end
 end


### PR DESCRIPTION
Hi,

I've found an issue, changing ```assets_prefix``` to custom caused ```linked_dirs``` array to contain a path with a default value of ```assets_prefix```.
before:
```ruby
set :assets_prefix, 'myassets'
linked_dirs: [..., public/assets, ...]
```
after:
```ruby
set :assets_prefix, 'myassets'
linked_dirs: [..., public/myassets, ...]
```

The reason of this issue is the assets path added to ```linked_dirs``` array in the ```load:defaults``` task, where the variable ```assets_prefix``` has the default value and is not yet overridden.