### PR TITLE
Add option to compile assets once, rsync everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ set :rails_env, 'staging'                  # If the environment differs from the
 set :migration_role, 'migrator'            # Defaults to 'db'
 set :conditionally_migrate, true           # Defaults to false. If true, it's skip migration if files in db/migrate not modified
 set :assets_roles, [:web, :app]            # Defaults to [:web]
+set :compile_assets_roles, [:compiler]     # Defaults to [], which means compilation runs on all :assets_roles
 set :assets_prefix, 'prepackaged-assets'   # Defaults to 'assets' this should match config.assets.prefix in your rails config/application.rb
 ```
 
@@ -52,6 +53,27 @@ Make sure you enable it by setting `linked_dirs` and `linked_files` options:
     # deploy.rb
     set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
     set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
+
+## Compilation & Distribution of Assets
+
+By default, each machine within `:asset_roles` compiles its own copy of the assets.
+This allows all machines to operate independently and without the need to directly
+access each other.
+
+In some instances, it is desirable to run this compilation on only one machine,
+then have the resultant files distributed to the rest. This can be accomplished
+by assigning a single machine to `:compile_assets_roles`.
+
+```ruby
+set :compile_assets_roles, [ :compiler ]
+
+server 'util01', user: 'deploy', roles: [:util, :compiler]
+```
+
+For this method to work, the other machines in `:asset_roles` must be able to
+directly reach the machine that compiles the assets (in this example, util01)
+using the details provided in the Capistrano configuration. They must also have
+`rsync` available to sync the asset files.
 
 ## Contributing
 


### PR DESCRIPTION
The current implementation of `deploy:compile_assets` runs `rake assets:precompile` on all machines configured for `:assets_roles`. That's fine for the majority of cases, but it started causing problems for us as the application grew. Running `assets:precompile` is CPU-intensive, and it was slowing down response times for app requests that came in during compilation. Furthermore, we have VMs partitioned out on dedicated hardware (HIPAA :unamused:), and so running that task on multiple VMs that were all sharing the same CPU meant we were basically becoming a noisy-neighbor to ourselves. Response time went up, request queueing time went up, and everyone had a bad time.

I solved this by running `assets:precompile` on a single utility box, and then using `rsync` to mirror it out to the rest of the machines in `:assets_roles`. This might be env-dependent (the rest of the machines need to be able to SSH to each other), but it solved the problem for us. Not sure if this solution is generalized enough to work for others, but thought I'd PR it anyways.

Because of that requirement it may require a bit of extra setup, so it defaults to off. You can enable it by setting `:compile_assets_roles` in *deploy.rb*, and then specifying a machine to do the compilation in your environment declaration. If this config option is not set, or if no machines are configured, it falls back to compiling on all `:assets_roles` machines. I added a section to the README that hopefully describes this.

Tested in a Rails 4.1.x app. One potential gotcha: the first time you enable it you may need to manually remove the manifest file from *public/assets* on each machine to ensure you don't end up with multiple manifest files that will then cause the backup manifest task to fail. If you don't enable the new feature it has no effect so this won't be a problem.