### PR TITLE
Allow to set RAILS_GROUPS for assets:precompile

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -55,7 +55,7 @@ namespace :deploy do
     task :precompile do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
             execute :rake, "assets:precompile"
           end
         end


### PR DESCRIPTION
It's useful to extract assets gems into separate group when there are too much of them.