### PR TITLE
Cleanup assets after:updated

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -24,7 +24,6 @@ namespace :deploy do
     invoke 'deploy:assets:backup_manifest'
   end
 
-  # FIXME: it removes every asset it has just compiled
   desc 'Cleanup expired assets'
   task :cleanup_assets => [:set_rails_env] do
     on release_roles(fetch(:assets_roles)) do
@@ -46,9 +45,8 @@ namespace :deploy do
   end
 
   after 'deploy:updated', 'deploy:compile_assets'
-  # NOTE: we don't want to remove assets we've just compiled
-  # after 'deploy:updated', 'deploy:cleanup_assets'
-  after 'deploy:updated', 'deploy:normalize_assets'
+  after 'deploy:updated', 'deploy:cleanup_assets'
+  after 'deploy:updated', 'deploy:normalise_assets'
   after 'deploy:reverted', 'deploy:rollback_assets'
 
   namespace :assets do


### PR DESCRIPTION
It looks like commit 73d912e899 was a misunderstanding of what sprockets does.
From the [sprockets README](https://github.com/rails/sprockets-rails/blob/master/README.md):
`rake assets:clean`
  Only removes old assets (keeps the most recent 3 copies) from public/assets. Useful when doing rolling deploys that may still be serving old assets while the new ones are being compiled.
