### PR TITLE
Fixing bug with normalize_assets typo

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -46,7 +46,7 @@ namespace :deploy do
 
   after 'deploy:updated', 'deploy:compile_assets'
   after 'deploy:updated', 'deploy:cleanup_assets'
-  after 'deploy:updated', 'deploy:normalise_assets'
+  after 'deploy:updated', 'deploy:normalize_assets'
   after 'deploy:reverted', 'deploy:rollback_assets'
 
   namespace :assets do


### PR DESCRIPTION
```normalise_assets``` was renamed to ```normalize_assets```[1], but wasn't changed in another place in code. This PR fixes that bug.

[1] https://github.com/capistrano/rails/blob/master/CHANGELOG.md#111