### PR TITLE
Load default config for migrations task correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+* Fix default values not being set if capistrano/migrations required after capistrano/setup
 * call `Array#uniq` in `deploy:set_linked_dirs` task to remove duplicated :linked_dirs
 * Add `migration_servers` configuration (#168)
 

--- a/lib/capistrano/rails/migrations.rb
+++ b/lib/capistrano/rails/migrations.rb
@@ -1,1 +1,4 @@
 load File.expand_path("../../tasks/migrations.rake", __FILE__)
+
+set_if_empty :conditionally_migrate, false
+set_if_empty :migration_role, :db

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -22,10 +22,3 @@ namespace :deploy do
 
   after 'deploy:updated', 'deploy:migrate'
 end
-
-namespace :load do
-  task :defaults do
-    set :conditionally_migrate, fetch(:conditionally_migrate, false)
-    set :migration_role, fetch(:migration_role, :db)
-  end
-end


### PR DESCRIPTION
With Capistrano 3.4.0 (at least, unverified in other versions), it only invokes `load:defaults` task during the require of `capistrano/setup`. We can't require `capistrano/migrations` until after that, so the default config values from `migrations.rake` are never set.

Instead, lets set them during the require of `capistrano/migrations`, using the `set_if_empty` method to make sure we don't override a user-provided setting.