### PR TITLE
Opt-in to deploy:cleanup_assets with :keep_assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* Disable `deploy:cleanup_assets` by default due to undesirable behavior in Rails 3. Use `set :keep_assets, 2` to explicitly enable this feature for Rails 4.
+
 # 1.1.4 (Oct 10 2015)
 
 * Fixing bug with normalize_assets typo #138

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ set :assets_prefix, 'prepackaged-assets'
 
 # If you need to touch public/images, public/javascripts, and public/stylesheets on each deploy
 set :normalize_asset_timestamps, %{public/images public/javascripts public/stylesheets}
+
+# Defaults to nil (no asset cleanup is performed)
+# If you use Rails 4+ and you'd like to clean up old assets after each deploy,
+# set this to the number of versions to keep
+set :keep_assets, 2
 ```
 
 ### Symlinks

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -26,10 +26,11 @@ namespace :deploy do
 
   desc 'Cleanup expired assets'
   task :cleanup_assets => [:set_rails_env] do
+    next unless fetch(:keep_assets)
     on release_roles(fetch(:assets_roles)) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "assets:clean"
+          execute :rake, "assets:clean[#{fetch(:keep_assets)}]"
         end
       end
     end


### PR DESCRIPTION
In Rails 3, the `rake assets:clean` tasks deletes *all* assets, which is obviously not the desired effect. To be safe, disable this task by default.

In Rails 4, `rake assets:clean` keeps the most recent 2 versions of assets by default, and can be further tweaked by specifying a number, like `rake assets:clean[5]` to keep 5 versions. To opt-in to this behavior, use e.g. `set :keep_assets, 5`. This will enable the cleanup task and pass the `5` value to rake.

Addresses #142 