### PR TITLE
Add rake bin override setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ You can tweak some Rails-specific options in `config/deploy.rb`:
 # If the environment differs from the stage name
 set :rails_env, 'staging'
 
+# Defaults to 'rake'
+# If the rake executable differs from 'rake'
+set :rake_bin, 'pitch_fork'
+
 # Defaults to 'db'
 set :migration_role, 'migrator'
 

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -30,7 +30,7 @@ namespace :deploy do
     on release_roles(fetch(:assets_roles)) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "assets:clean[#{fetch(:keep_assets)}]"
+          execute fetch(:rake_bin), "assets:clean[#{fetch(:keep_assets)}]"
         end
       end
     end
@@ -55,7 +55,7 @@ namespace :deploy do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
           with rails_env: fetch(:rails_env) do
-            execute :rake, "assets:precompile"
+            execute fetch(:rake_bin), "assets:precompile"
           end
         end
       end
@@ -119,5 +119,6 @@ namespace :load do
   task :defaults do
     set :assets_roles, fetch(:assets_roles, [:web])
     set :assets_prefix, fetch(:assets_prefix, 'assets')
+    set :rake_bin, fetch(:rake_bin, :rake)
   end
 end

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -13,7 +13,7 @@ namespace :deploy do
         info '[deploy:migrate] Run `rake db:migrate`'
         within release_path do
           with rails_env: fetch(:rails_env) do
-            execute :rake, "db:migrate"
+            execute fetch(:rake_bin), "db:migrate"
           end
         end
       end
@@ -27,5 +27,6 @@ namespace :load do
   task :defaults do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
+    set :rake_bin, fetch(:rake_bin, :rake)
   end
 end


### PR DESCRIPTION
We utilize a wrapper rake script for a few things, so this adds the option to override the default rake bin in our deploys.

Sheepish admission: first capistrano submission, so let me know if I'm missing an obvious alternative way of achieving the same goal.