### PR TITLE
allow projects to require only 'capistrano/rails/set_rails_env'

### DIFF
--- a/lib/capistrano/rails/assets.rb
+++ b/lib/capistrano/rails/assets.rb
@@ -1,1 +1,2 @@
+require 'capistrano/rails/set_rails_env'
 load File.expand_path("../../tasks/assets.rake", __FILE__)

--- a/lib/capistrano/rails/migrations.rb
+++ b/lib/capistrano/rails/migrations.rb
@@ -1,1 +1,2 @@
+require 'capistrano/rails/set_rails_env'
 load File.expand_path("../../tasks/migrations.rake", __FILE__)

--- a/lib/capistrano/rails/set_rails_env.rb
+++ b/lib/capistrano/rails/set_rails_env.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../../tasks/set_rails_env.rake", __FILE__)

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,5 +1,3 @@
-load File.expand_path("../set_rails_env.rake", __FILE__)
-
 module Capistrano
   class FileNotFound < StandardError
   end

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -1,5 +1,3 @@
-load File.expand_path("../set_rails_env.rake", __FILE__)
-
 namespace :deploy do
 
   desc 'Runs rake db:migrate if migrations are set'


### PR DESCRIPTION
this is useful for projects which don't use assets or migrations, but still want to use rails_env variable for other purposes.