### PR TITLE
allow for a "actually migrating"-hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* Split `deploy:migrate` to allow for finer hook-control
+
 # 1.1.5 (Oct 15 2015)
 
 * Disable `deploy:cleanup_assets` by default due to undesirable behavior in Rails 3. Use `set :keep_assets, 2` to explicitly enable this feature for Rails 4.

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -16,6 +16,7 @@ namespace :deploy do
     end
   end
 
+  desc 'Runs rake db:migrate'
   task migrating: [:set_rails_env] do
     on primary fetch(:migration_role) do
       within release_path do

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -11,10 +11,16 @@ namespace :deploy do
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate)'
       else
         info '[deploy:migrate] Run `rake db:migrate`'
-        within release_path do
-          with rails_env: fetch(:rails_env) do
-            execute :rake, "db:migrate"
-          end
+        invoke :'deploy:migrating'
+      end
+    end
+  end
+
+  task migrating: [:set_rails_env] do
+    on primary fetch(:migration_role) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, 'db:migrate'
         end
       end
     end


### PR DESCRIPTION
### Background

We want to disable the website with a maintenance-page when we migrate the database. In capistrano2, this was a manual decision by the person deploying. capistrano3 and capistrano-rails now offers the option to `conditionally_migrate`. 

### Changes

I extracted the actual migration-task from the current task into `deploy:migrating`.

This allows us to apply our hooks for the 503-page only if migrations are actually run.

### Questions / Loose Ends

If this project is maintained similar to capistrano itself, I can squash all commits into one and rebase onto the then current master.

I am open and unsure on how to name the extracted task. I vaguely based the name in this PR on the hooks I found in capistrano itself. However, my first version was `deploy:really_migrate`.

I tested this in the project which triggered the need.