### PR TITLE
Escape [ and ] when calling assets:clean rake task

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -30,7 +30,7 @@ namespace :deploy do
     on release_roles(fetch(:assets_roles)) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, "assets:clean[#{fetch(:keep_assets)}]"
+          execute :rake, "'assets:clean[#{fetch(:keep_assets)}]'"
         end
       end
     end


### PR DESCRIPTION
Zsh uses [ and ] as special character for globbing files.
If not escaped, the "rake assets:clean[...]" will throw an error when
using zsh on the server.