### PR TITLE
Complete installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,18 @@ gem 'capistrano', '~> 3.1'
 gem 'capistrano-rails', '~> 1.1'
 ```
 
+Run the following command to install the gems:
+
+```
+bundle install
+```
+
+Then run the generator to create a basic set of configuration files:
+
+```
+bundle exec cap install
+```
+
 ## Usage
 
 Require everything (`bundler`, `rails/assets` and `rails/migrations`):


### PR DESCRIPTION
Add the `cap install` command to the installation section. The following parts of the guide refer to the Capfile for example, which is only created if the command is run.