### PR TITLE
call Array#uniq to remove duplicated :linked_dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# master
+
+* call `Array#uniq` in `deploy:set_linked_dirs` task to remove duplicated :linked_dirs
+
 # 1.1.6 (Jan 19 2016)
 
 * Add `rake assets:clobber` task from Rails (#149)

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -120,7 +120,7 @@ end
 # as assets_prefix will always have a default value
 namespace :deploy do
   task :set_linked_dirs do
-    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}")
+    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}").uniq
   end
 end
 


### PR DESCRIPTION
capistrano/rails run `:set_linked_dirs` after user sets :linked_dirs in deploy.rb. It's likely that "public/assets" exists in :linked_dirs already.