### PR TITLE
Control if migrations should be executed after deploy:updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ set :migration_role, 'migrator'
 # Skip migration if files in db/migrate were not modified
 set :conditionally_migrate, true
 
+# Defauls to false
+# Skip migrations to be run after the deploy:updated task
+set :skip_migrations_on_deploy, true
+
 # Defaults to [:web]
 set :assets_roles, [:web, :app]
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ set :migration_role, 'migrator'
 # Skip migration if files in db/migrate were not modified
 set :conditionally_migrate, true
 
-# Defauls to false
+# Defauls to true
 # Skip migrations to be run after the deploy:updated task
-set :skip_migrations_on_deploy, true
+set :migrate_on_deploy, false
 
 # Defaults to [:web]
 set :assets_roles, [:web, :app]

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -13,7 +13,7 @@ namespace :deploy do
         info '[deploy:migrate] Run `rake db:migrate`'
         invoke :'deploy:migrating'
       end
-    end unless fetch(:skip_migrations_on_deploy)
+    end if fetch(:migrate_on_deploy)
   end
 
   desc 'Runs rake db:migrate'
@@ -34,6 +34,6 @@ namespace :load do
   task :defaults do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
-    set :skip_migrations_on_deploy, fetch(:skip_migrations_on_deploy, false)
+    set :migrate_on_deploy, fetch(:migrate_on_deploy, true)
   end
 end

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -13,7 +13,7 @@ namespace :deploy do
         info '[deploy:migrate] Run `rake db:migrate`'
         invoke :'deploy:migrating'
       end
-    end
+    end unless fetch(:skip_migrations_on_deploy)
   end
 
   desc 'Runs rake db:migrate'
@@ -34,5 +34,6 @@ namespace :load do
   task :defaults do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
+    set :skip_migrations_on_deploy, fetch(:skip_migrations_on_deploy, false)
   end
 end


### PR DESCRIPTION
This PR allows to control whether migrations should be run upon deploy. Sometimes you may need to run migrations after the actual deploy. For example, if a migration locks the DB, etc. A common case is adding an index to your DB, the functionality is the same, but the addition can cause locks. In this case you may need to run the migration later, but still need to deploy the code.

This PR allows to skip that behavior by setting a variable.

``` ruby
set :skip_migrations_on_deploy, true
```

This way, if that variable is set to true no migration will be executed when deploying, but the migrate task is preserved. Also, the default behavior is to do what is being done now.

Thanks for the gem!
