### PR TITLE
Allow overriding migration servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # master
 
 * call `Array#uniq` in `deploy:set_linked_dirs` task to remove duplicated :linked_dirs
+* Add `migration_servers` configuration (#168)
 
 # 1.1.6 (Jan 19 2016)
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ set :normalize_asset_timestamps, %{public/images public/javascripts public/style
 # If you use Rails 4+ and you'd like to clean up old assets after each deploy,
 # set this to the number of versions to keep
 set :keep_assets, 2
+
+# Defaults to the primary :db server
+set :migration_role, :db
+set :migration_servers, -> { primary(fetch(:migration_role)) }
 ```
 
 ### Symlinks

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -4,7 +4,7 @@ namespace :deploy do
 
   desc 'Runs rake db:migrate if migrations are set'
   task :migrate => [:set_rails_env] do
-    on primary fetch(:migration_role) do
+    on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
       info '[deploy:migrate] Checking changes in /db/migrate' if conditionally_migrate
       if conditionally_migrate && test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate")
@@ -18,7 +18,7 @@ namespace :deploy do
 
   desc 'Runs rake db:migrate'
   task migrating: [:set_rails_env] do
-    on primary fetch(:migration_role) do
+    on fetch(:migration_servers) do
       within release_path do
         with rails_env: fetch(:rails_env) do
           execute :rake, 'db:migrate'
@@ -34,5 +34,6 @@ namespace :load do
   task :defaults do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
+    set :migration_servers, -> { primary(fetch(:migration_role)) }
   end
 end


### PR DESCRIPTION
This would enable users to run migrations on multiple servers. I've seen this being discussed at https://github.com/capistrano/capistrano/issues/1449.

Unlike https://github.com/capistrano/rails/pull/127, it doesn't change the existing functionality. And unlike https://github.com/capistrano/rails/pull/126 it actually works.

In our case, we would be able to override the `migration_servers` value with `set :migration_servers, -> { release_roles(fetch(:migration_role)) }`