### PR TITLE
Can require set_rails_env

### DIFF
--- a/lib/capistrano/rails/set_rails_env.rb
+++ b/lib/capistrano/rails/set_rails_env.rb
@@ -1,0 +1,1 @@
+load File.expand_path("../../tasks/set_rails_env.rake", __FILE__)


### PR DESCRIPTION
Want `set_rails_env` for a custom database migration

but do not want to require `capistrano/rails/migrations`
and there are no assets yet as well so no `capistrano/rails/assets` :-)

so this small PR add a require for `capistrano/rails/set_rails_env`