### PR TITLE
Recommendation for setting role to :app

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
 set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/secrets.yml')
 ```
 
+### Recommendations
+
+While migrations looks like a concern of the database layer, Rails migrations
+are strictly related to the framework. It's recommended so, to set the role to
+`:app` instead of `:db` like:
+
+```ruby
+set :migration_role, :app
+set :migration_servers, -> { release_roles(fetch(:migration_role)) }
+```
+
+The advantage is you won't need to deploy your application to your database
+server, and overall a better separation of concerns.
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -94,12 +94,11 @@ set :linked_files, fetch(:linked_files, []).push('config/database.yml', 'config/
 ### Recommendations
 
 While migrations looks like a concern of the database layer, Rails migrations
-are strictly related to the framework. It's recommended so, to set the role to
-`:app` instead of `:db` like:
+are strictly related to the framework. Therefore, it's recommended to set the
+role to `:app` instead of `:db` like:
 
 ```ruby
 set :migration_role, :app
-set :migration_servers, -> { release_roles(fetch(:migration_role)) }
 ```
 
 The advantage is you won't need to deploy your application to your database


### PR DESCRIPTION
As discussed on https://github.com/capistrano/rails/issues/181#issuecomment-242864503
without changing the base code, added a recommendation on README file to use `:app` as role (with example)

Please discuss, I'm not entirely sure if a **Recommendations** section is good or should be located in a different place.