### PR TITLE
diff schema.rb instead of migrations directory

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -7,7 +7,7 @@ namespace :deploy do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
       info '[deploy:migrate] Checking changes in /db/migrate' if conditionally_migrate
-      if conditionally_migrate && test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate")
+      if conditionally_migrate && test("diff -q #{release_path}/db/schema.rb #{current_path}/db/schema.rb")
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate)'
       else
         info '[deploy:migrate] Run `rake db:migrate`'


### PR DESCRIPTION
I have a project that dynamically includes migrations from rails engine(s). The engine migration files aren't in `db/migrate`, so diffing that directory wasn't catching changes to my database.

It may be a better idea to just diff the whole db directory, but the simplest change for my use-case was to just diff the schema.rb.

There aren't any tests so ¯\\\(°_o)/¯ 