### PR TITLE
Handle arrays in normalize_asset_timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+* Handle arrays passed into `normalize_asset_timestamps` correctly (#184)
 * Your contribution here!
 
 # 1.1.7 (Jun 10 2016)

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -9,10 +9,11 @@ namespace :deploy do
   desc 'Normalize asset timestamps'
   task :normalize_assets => [:set_rails_env] do
     on release_roles(fetch(:assets_roles)) do
-      assets = fetch(:normalize_asset_timestamps)
-      if assets
+      assets = fetch(:normalize_asset_timestamps, [])
+      assets = [assets] unless assets.respond_to?(:any?)
+      if assets.any?
         within release_path do
-          execute :find, "#{assets} -exec touch -t #{asset_timestamp} {} ';'; true"
+          execute :find, "#{assets.join(' ')} -exec touch -t #{asset_timestamp} {} ';'; true"
         end
       end
     end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -9,8 +9,7 @@ namespace :deploy do
   desc 'Normalize asset timestamps'
   task :normalize_assets => [:set_rails_env] do
     on release_roles(fetch(:assets_roles)) do
-      assets = fetch(:normalize_asset_timestamps, [])
-      assets = [assets] unless assets.respond_to?(:any?)
+      assets = Array(fetch(:normalize_asset_timestamps, []))
       if assets.any?
         within release_path do
           execute :find, "#{assets.join(' ')} -exec touch -t #{asset_timestamp} {} ';'; true"


### PR DESCRIPTION
It looks like the Readme describes usages like so:

```ruby
set :normalize_asset_timestamps, %w{public/images public/javascripts public/stylesheets}
```

Yet as seen in https://github.com/capistrano/rails/issues/184, this doesn't actually work.

This PR tries to fix this case.