### PR TITLE
Diff db directory recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # [master][]
 
+* Diff db directory recursively
 * Your contribution here!
 
 # [1.2.0][] (Oct 25 2016)

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -7,7 +7,7 @@ namespace :deploy do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
       info '[deploy:migrate] Checking changes in db' if conditionally_migrate
-      if conditionally_migrate && test("diff -q #{release_path}/db #{current_path}/db")
+      if conditionally_migrate && test("diff -qr #{release_path}/db #{current_path}/db")
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db)'
       else
         info '[deploy:migrate] Run `rake db:migrate`'


### PR DESCRIPTION
#186 introduced diffing the entire db directory, but the problem is some people do not store schema dumps under version control (to avoid merging) and the `diff` command is not recursive by default, so changes in db/migrate are not picked up. This PR sets `diff` to work recursively