### PR TITLE
switch require order of assets and migrations

### DIFF
--- a/lib/capistrano/rails.rb
+++ b/lib/capistrano/rails.rb
@@ -1,3 +1,3 @@
 require 'capistrano/bundler'
-require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
+require 'capistrano/rails/assets'


### PR DESCRIPTION
so that migrations run before assets are compiled. Been stung by this a couple of times - initializers expecting the db to in a certain state getting run when assets are compiled, prior to migrations running. 