### PR TITLE
Call diff using sshkit's command map

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -7,7 +7,7 @@ namespace :deploy do
     on fetch(:migration_servers) do
       conditionally_migrate = fetch(:conditionally_migrate)
       info '[deploy:migrate] Checking changes in db' if conditionally_migrate
-      if conditionally_migrate && test("diff -qr #{release_path}/db #{current_path}/db")
+      if conditionally_migrate && test(:diff, "-qr #{release_path}/db #{current_path}/db")
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db)'
       else
         info '[deploy:migrate] Run `rake db:migrate`'


### PR DESCRIPTION
To allow overriding of the diff binary location when required. Eg, when you have `/usr/bin/diff` but you want capistrano to call `/opt/local/bin/diff` instead, you can configure this with

```ruby
SSHKit.config.command_map[:diff] = "/opt/local/bin/diff"
```

and capistrano-rails will now call the correct binary when invoking diff.