### PR TITLE
Don't link public/assets if public is linked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* [#200](https://github.com/capistrano/rails/pull/200): Don't link public/assets if public is already linked - [@mattbrictson](https://github.com/mattbrictson)
 
 # [1.2.2][] (Jan 10 2017)
 

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -120,7 +120,11 @@ end
 # as assets_prefix will always have a default value
 namespace :deploy do
   task :set_linked_dirs do
-    set :linked_dirs, fetch(:linked_dirs, []).push("public/#{fetch(:assets_prefix)}").uniq
+    linked_dirs = fetch(:linked_dirs, [])
+    unless linked_dirs.include?('public')
+      linked_dirs << "public/#{fetch(:assets_prefix)}"
+      set :linked_dirs, linked_dirs.uniq
+    end
   end
 end
 


### PR DESCRIPTION
If the user has already added "public" to Capistrano's `:linked_dirs`, then further linking "public/assets" is not only unnecessary, it causes conflicts and asset precompilation fails as a result.

Fix this by checking if "public" is already linked, and if so, skip linking "public/assets".

Fixes #151.