### PR TITLE
Run any rake task on remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* [#209](https://github.com/capistrano/rails/pull/209): Run any rake task on remote - [@stoivo](https://github.com/stoivo)
 
 # [1.3.0][] (Jun 9 2017)
 

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -29,6 +29,17 @@ namespace :deploy do
   end
 
   after 'deploy:updated', 'deploy:migrate'
+
+  desc 'Runs any rake task, cap deploy:rake task=db:rollback'
+  task rake: [:set_rails_env] do
+    on fetch(:migration_servers) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :rake, ENV['task']
+        end
+      end
+    end
+  end
 end
 
 namespace :load do


### PR DESCRIPTION
Our company uses rake task to migrate data. 
It would be nice If capistrano-rails provided this. I check out the code and this is the smallest amount of code I could add to make it work simply. I know I could package it up and ship it as a separate gem out of I don't see how anybody would benefit from that. 

Probably I should not use migration_servers always, but make it configurable?
Are you interested in adding this? 