### PR TITLE
Added option ':assets_manifests' to support custom manifest file path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # [master][]
 
 * Your contribution here!
-* Added option ':assets_manifest' to support custom manifest file path ([#215](https://github.com/capistrano/rails/pull/215))
+* Added option ':assets_manifests' to support custom manifest file path ([#216](https://github.com/capistrano/rails/pull/216))
 
 # [1.3.1][] (Nov 21 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* Added option ':assets_manifest' to support custom manifest file path ([#215](https://github.com/capistrano/rails/pull/215))
 
 # [1.3.1][] (Nov 21 2017)
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ set :assets_roles, [:web, :app]
 # This should match config.assets.prefix in your rails config/application.rb
 set :assets_prefix, 'prepackaged-assets'
 
+# Defaults to nil
+# This should match config.assets.manifest in your rails config/application.rb
+set :assets_manifest, 'app/assets/config/manifest.js'
+
 # RAILS_GROUPS env value for the assets:precompile task. Default to nil.
 set :rails_assets_groups, :assets
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ set :assets_roles, [:web, :app]
 # This should match config.assets.prefix in your rails config/application.rb
 set :assets_prefix, 'prepackaged-assets'
 
-# Defaults to nil
+# Defaults to ["/path/to/release_path/public/#{fetch(:assets_prefix)}/.sprockets-manifest*", "/path/to/release_path/public/#{fetch(:assets_prefix)}/manifest*.*"]
 # This should match config.assets.manifest in your rails config/application.rb
-set :assets_manifest, 'app/assets/config/manifest.js'
+set :assets_manifests, ['app/assets/config/manifest.js']
 
 # RAILS_GROUPS env value for the assets:precompile task. Default to nil.
 set :rails_assets_groups, :assets

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -102,11 +102,11 @@ namespace :deploy do
     end
 
     def detect_manifest_path
-      manifests = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : %w(.sprockets-manifest* manifest*.*)
+      manifests = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : %w[.sprockets-manifest* manifest*.*]
       manifests.each do |pattern|
-        manifest_path = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : ['public', fetch(:assets_prefix), pattern]
+        manifest_path = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : ["public", fetch(:assets_prefix), pattern]
         candidate = release_path.join(*manifest_path)
-        return capture(:ls, candidate).strip.gsub(/(\r|\n)/,' ') if test(:ls, candidate)
+        return capture(:ls, candidate).strip.gsub(/(\r|\n)/, ' ') if test(:ls, candidate)
       end
       msg = 'Rails assets manifest file not found.'
       warn msg

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -102,11 +102,10 @@ namespace :deploy do
     end
 
     def detect_manifest_path
-      %w(
-        .sprockets-manifest*
-        manifest*.*
-      ).each do |pattern|
-        candidate = release_path.join('public', fetch(:assets_prefix), pattern)
+      manifests = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : %w(.sprockets-manifest* manifest*.*)
+      manifests.each do |pattern|
+        manifest_path = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : ['public', fetch(:assets_prefix), pattern]
+        candidate = release_path.join(*manifest_path)
         return capture(:ls, candidate).strip.gsub(/(\r|\n)/,' ') if test(:ls, candidate)
       end
       msg = 'Rails assets manifest file not found.'

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -102,10 +102,7 @@ namespace :deploy do
     end
 
     def detect_manifest_path
-      manifests = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : %w[.sprockets-manifest* manifest*.*]
-      manifests.each do |pattern|
-        manifest_path = fetch(:assets_manifest) ? [fetch(:assets_manifest)] : ["public", fetch(:assets_prefix), pattern]
-        candidate = release_path.join(*manifest_path)
+      fetch(:assets_manifests).each do |candidate|
         return capture(:ls, candidate).strip.gsub(/(\r|\n)/, ' ') if test(:ls, candidate)
       end
       msg = 'Rails assets manifest file not found.'
@@ -133,5 +130,10 @@ namespace :load do
   task :defaults do
     set :assets_roles, fetch(:assets_roles, [:web])
     set :assets_prefix, fetch(:assets_prefix, 'assets')
+    set :assets_manifests, -> {
+      %w[.sprockets-manifest* manifest*.*].map do |pattern|
+        release_path.join("public", fetch(:assets_prefix), pattern)
+      end
+    }
   end
 end


### PR DESCRIPTION
Added option ':assets_manifest' to support custom manifest file path.

Without this option and set `config.assets.manifest` in `config/application.rb`, the following error message appears.

```console
DEBUG [30163db1] Running /usr/bin/env ls /path/to/releases/xxx/public/assets/.sprockets-manifest* as yourname@yourhost
DEBUG [30163db1] Command: cd /path/to/releases/xxx && /usr/bin/env ls /path/to/releases/xxx/public/assets/.sprockets-manifest*
DEBUG [30163db1] 	ls: 
DEBUG [30163db1] 	cannot access /path/to/releases/xxx/public/assets/.sprockets-manifest*
DEBUG [30163db1] 	: No such file or directory
DEBUG [30163db1] 	

DEBUG [30163db1] Finished in 0.325 seconds with exit status 2 (failed).
DEBUG [3e09dcf0] Running /usr/bin/env ls /path/to/releases/xxx/public/assets/manifest*.* as yourname@yourhost
DEBUG [3e09dcf0] Command: cd /path/to/releases/xxx && /usr/bin/env ls /path/to/releases/xxx/public/assets/manifest*.*
DEBUG [3e09dcf0] 	ls: 
DEBUG [3e09dcf0] 	cannot access /path/to/releases/xxx/public/assets/manifest*.*
DEBUG [3e09dcf0] 	: No such file or directory
DEBUG [3e09dcf0] 	

DEBUG [3e09dcf0] Finished in 0.293 seconds with exit status 2 (failed).
WARN Rails assets manifest file not found.
(Backtrace restricted to imported tasks)
cap aborted!
```

`config.assets.manifest` is used in https://github.com/rails/sprockets-rails.