### PR TITLE
Recommend `require: false` in Gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ Rails specific tasks for Capistrano v3:
 
 ## Installation
 
-Add these lines to your application's Gemfile:
+Add these Capistrano gems to your application's Gemfile using `require: false`:
 
 ```ruby
 group :development do
-  gem 'capistrano', '~> 3.6'
-  gem 'capistrano-rails', '~> 1.3'
+  gem "capistrano", "~> 3.10", require: false
+  gem "capistrano-rails", "~> 1.3", require: false
 end
 ```
 


### PR DESCRIPTION
Capistrano gems shouldn't be loaded within a Rails (or any) app. They are intended to be used by the cap command, not within Rails itself. At best, `require: true` (the default) is unnecessary; at worst, it can cause conflicts as encountered here:

https://stackoverflow.com/q/48493332/4625365

Update our docs to recommend `require: false` just to be safe.

Related: https://github.com/capistrano/capistrano/pull/1964