### PR TITLE
Fix for root assets_prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* [#220](https://github.com/capistrano/rails/pull/220): Fix for root assets_prefix - [@Fudoshiki](https://github.com/Fudoshiki)
 
 # [1.3.1][] (Nov 21 2017)
 

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -122,7 +122,7 @@ namespace :deploy do
   task :set_linked_dirs do
     linked_dirs = fetch(:linked_dirs, [])
     unless linked_dirs.include?('public')
-      linked_dirs << "public/#{fetch(:assets_prefix)}"
+      linked_dirs << "public#{"/#{fetch(:assets_prefix)}" unless fetch(:assets_prefix).empty? }"
       set :linked_dirs, linked_dirs.uniq
     end
   end


### PR DESCRIPTION
Fixes `ln stderr: ln: target '/srv/webapp/repository/releases/20180224132230/public/' is not a directory: No such file or directory` when `set :assets_prefix, ''`
