### PR TITLE
handle restore of multiple asset manifests on rollback

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -88,10 +88,15 @@ namespace :deploy do
     task :restore_manifest do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
-          target = detect_manifest_path
-          source = release_path.join('assets_manifest_backup', File.basename(target))
-          if test "[[ -f #{source} && -f #{target} ]]"
-            execute :cp, source, target
+          targets = detect_manifest_path.split(' ')
+          sources = targets.map do |target|
+            release_path.join('assets_manifest_backup', File.basename(target))
+          end
+          if test(:ls, sources) && test(:ls, targets)
+            source_map = targets.zip(sources).to_h
+            source_map.each do |(source, target)|
+              execute :cp, source, target
+            end
           else
             msg = 'Rails assets manifest file (or backup file) not found.'
             warn msg

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -92,7 +92,7 @@ namespace :deploy do
           sources = targets.map do |target|
             release_path.join('assets_manifest_backup', File.basename(target))
           end
-          if test(:ls, sources) && test(:ls, targets)
+          if test(:ls, *sources) && test(:ls, *targets)
             source_map = sources.zip(targets)
             source_map.each do |source, target|
               execute :cp, source, target

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -93,7 +93,7 @@ namespace :deploy do
             release_path.join('assets_manifest_backup', File.basename(target))
           end
           if test(:ls, sources) && test(:ls, targets)
-            source_map = targets.zip(sources)
+            source_map = sources.zip(targets)
             source_map.each do |source, target|
               execute :cp, source, target
             end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -93,8 +93,8 @@ namespace :deploy do
             release_path.join('assets_manifest_backup', File.basename(target))
           end
           if test(:ls, sources) && test(:ls, targets)
-            source_map = targets.zip(sources).to_h
-            source_map.each do |(source, target)|
+            source_map = targets.zip(sources)
+            source_map.each do |source, target|
               execute :cp, source, target
             end
           else


### PR DESCRIPTION
Handle multiple manifest files gracefully.

Related to #123 this PR will fix issues with multiple sprockets asset manifest files lying around in `#{shared_path}/public/assets/` and `#{release_path}/assets_manifest_backup` on  `cap <stage> deploy:rollback`.

Currently this will fail due to multiple filepaths being interpolated into a single shell `if` condition:

```
if test "[[ -f #{source} && -f #{target} ]]"
```
see https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/assets.rake#L93 and https://github.com/capistrano/rails/issues/204#issuecomment-404118165

To deal with this `restore_manifest` will explicitly copy _each_ of these files in a separate `cp` command.

Feedback on how to improve this PR is very welcome!

