### PR TITLE
Add changelog_uri to metadata to easily link from rubygems.org

### DIFF
--- a/capistrano-rails.gemspec
+++ b/capistrano-rails.gemspec
@@ -10,6 +10,9 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Rails specific Capistrano tasks}
   gem.summary       = %q{Rails specific Capistrano tasks}
   gem.homepage      = "https://github.com/capistrano/rails"
+  gem.metadata      = {
+    "changelog_uri" => "https://github.com/capistrano/rails/blob/master/CHANGELOG.md"
+  }
 
   gem.licenses      = ["MIT"]
 


### PR DESCRIPTION
Reference: https://guides.rubygems.org/specification-reference/#metadata