### PR TITLE
Add migration_command accessor for overriding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # [master][]
 
 * Your contribution here!
+* Added option `:migration_command` to allow overriding the default `db:migrate` used.
 
 # [1.5.0][] (May 15 2020)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ set :migration_role, :db
 # Defaults to the primary :db server
 set :migration_servers, -> { primary(fetch(:migration_role)) }
 
+# Defaults to `db:migrate`
+set :migration_command, 'db:migrate'
+
 # Defaults to false
 # Skip migration if files in db/migrate were not modified
 set :conditionally_migrate, true

--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -22,7 +22,7 @@ namespace :deploy do
     on fetch(:migration_servers) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :rake, 'db:migrate'
+          execute :rake, fetch(:migration_command)
         end
       end
     end
@@ -36,5 +36,6 @@ namespace :load do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
     set :migration_servers, -> { primary(fetch(:migration_role)) }
+    set :migration_command, -> { fetch(:migration_command, 'db:migrate') }
   end
 end


### PR DESCRIPTION
### Summary

Exposing the accessor `migration_command` allows more flexibility in running migrations.

With rails 6 multiple database support the `db:migrate` command isn't always what is needed when deploying to an environment.

Other usecases can include only running migrations for one of the databases, using something like `db:migrate:primary`.

### Short checklist

- [x] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

Our app only has access to migrate one of the databases the rails application connects to, so currently we get an error when trying to deploy without this change.

A side note, locally when I run the deployment but pointing to our fork of this gem I need to use `bundle exec cap` instead of just `cap`, just incase anybody else tries using the fork.

Thanks for the great library! ❤️ Let me know if you need any changes.