### PR TITLE
Use the latest version of capistrano-bundler

### DIFF
--- a/capistrano-rails.gemspec
+++ b/capistrano-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 3.1'
-  gem.add_dependency 'capistrano-bundler', '>= 1.1'
+  gem.add_dependency 'capistrano-bundler', '>= 1.1', '< 3'
 
   gem.add_development_dependency 'danger'
 end

--- a/capistrano-rails.gemspec
+++ b/capistrano-rails.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'capistrano', '~> 3.1'
-  gem.add_dependency 'capistrano-bundler', '~> 1.1'
+  gem.add_dependency 'capistrano-bundler', '>= 1.1'
 
   gem.add_development_dependency 'danger'
 end


### PR DESCRIPTION
capistrano-bundler 2.0.0 has been released and fixes Bundler deprecation warnings. This commit updates our gemspec so that capistrano-bundler 2.0.0 can be used with capistrano-rails.
