### PR TITLE
Fix SystemStackError when running deploy:migrate

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -36,6 +36,6 @@ namespace :load do
     set :conditionally_migrate, fetch(:conditionally_migrate, false)
     set :migration_role, fetch(:migration_role, :db)
     set :migration_servers, -> { primary(fetch(:migration_role)) }
-    set :migration_command, -> { fetch(:migration_command, 'db:migrate') }
+    set :migration_command, fetch(:migration_command, 'db:migrate')
   end
 end


### PR DESCRIPTION
The `:migration_command` setting added in 1.6.0 was self-referential, causing an infinite loop and a `SystemStackError`. Fix by removing the lambda declaration that caused this loop.

Fixes #246 

