### PR TITLE
Use migration command to construct log message

### DIFF
--- a/lib/capistrano/tasks/migrations.rake
+++ b/lib/capistrano/tasks/migrations.rake
@@ -10,7 +10,7 @@ namespace :deploy do
       if conditionally_migrate && test(:diff, "-qr #{release_path}/db #{current_path}/db")
         info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db)'
       else
-        info '[deploy:migrate] Run `rake db:migrate`'
+        info "[deploy:migrate] Run `rake #{fetch(:migration_command)}`"
         # NOTE: We access instance variable since the accessor was only added recently. Once capistrano-rails depends on rake 11+, we can revert the following line
         invoke :'deploy:migrating' unless Rake::Task[:'deploy:migrating'].instance_variable_get(:@already_invoked)
       end


### PR DESCRIPTION
### Summary

This is a follow-up to #242 , which introduced the `migration_command` configuration option. It's a great option that we're keen to use (as we use data migrations in our project). When upgrading, I noticed that the informational log message still says "Running `rake db:migrate`", even if a different migration command is provided.

This PR updates the log message to also dynamically print a message based on the provided migration command.

### Short checklist

- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?

### Other Information

☝️ I'm not sure where to make the CHANGELOG entry. If you could point me in the right direction, I can add a note about this change to the appropriate CHANGELOG, thanks!
