### PR TITLE
Remove CHANGELOG requirement from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,16 +8,9 @@ request... were there any bugs you had fixed? If so, mention them. If
 these bugs have open GitHub issues, be sure to tag them here as well,
 to keep the conversation linked together.
 
-### Short checklist
-
-- [ ] If you are fixing a bug or introducing a new feature, did you add a CHANGELOG entry?
-
 ### Other Information
 
 If there's anything else that's important and relevant to your pull
 request, mention that information here.
-
-If you are updating any of the CHANGELOG files or are asked to update the
-CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file where indicated.
 
 Thanks for helping improve Capistrano!


### PR DESCRIPTION
Release notes are now generated automatically, so contributors no longer need to edit the CHANGELOG.
