### PR TITLE
un-sequence master.key upload task, see #231

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ append :linked_files, "config/master.key"
 namespace :deploy do
   namespace :check do
     before :linked_files, :set_master_key do
-      on roles(:app), in: :sequence, wait: 10 do
+      on roles(:app) do
         unless test("[ -f #{shared_path}/config/master.key ]")
           upload! 'config/master.key', "#{shared_path}/config/master.key"
         end


### PR DESCRIPTION
### Summary

Using `sequence` and `wait` adds a ten second delay when talking to each server. 10 servers = 100 seconds added to each deploy. This will save gajillions of seconds for capistrano enthusiasts everywhere. 

### Other Information

Thanks for all your hard work guys!