### PR TITLE
Default :keep_assets to nil to eliminate cap-doctor warning.

### DIFF
--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -140,5 +140,6 @@ namespace :load do
         release_path.join("public", fetch(:assets_prefix), pattern)
       end
     }
+    set :keep_assets, nil
   end
 end


### PR DESCRIPTION
### Summary

First mentioned in #251, then once again in #262, when setting a value for `:keep_assets`, `cap doctor` will emit a warning: 

``` ruby 
# deploy.rb
set :keep_assets, -> { fetch(:keep_releases, 5) }
```

``` shell 
cap staging doctor 
# ...
# ....snipped for brevity
    :keep_assets is not a recognized Capistrano setting (/Users/jason.poll/.rbenv/versions/3.1.2/lib/ruby/3.1.0/delegate.rb:87)
```

Using: 
- ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
- capistrano (3.17.3)
- capistrano-rails (1.6.2)


