### PR TITLE
Add Propshaft `.manifest.json` to assets_manifests for support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ set :assets_roles, [:web, :app]
 # This should match config.assets.prefix in your rails config/application.rb
 set :assets_prefix, 'prepackaged-assets'
 
-# Defaults to ["/path/to/release_path/public/#{fetch(:assets_prefix)}/.sprockets-manifest*", "/path/to/release_path/public/#{fetch(:assets_prefix)}/manifest*.*"]
+# Defaults to ["/path/to/release_path/public/#{fetch(:assets_prefix)}/.sprockets-manifest*", "/path/to/release_path/public/#{fetch(:assets_prefix)}/manifest*.*", "/path/to/release_path/public/#{fetch(:assets_prefix)}/.manifest.json"]
 # This should match config.assets.manifest in your rails config/application.rb
 set :assets_manifests, ['app/assets/config/manifest.js']
 

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -136,7 +136,7 @@ namespace :load do
     set :assets_roles, fetch(:assets_roles, [:web])
     set :assets_prefix, fetch(:assets_prefix, 'assets')
     set :assets_manifests, -> {
-      %w[.sprockets-manifest* manifest*.*].map do |pattern|
+      %w[.sprockets-manifest* manifest*.* .manifest.json].map do |pattern|
         release_path.join("public", fetch(:assets_prefix), pattern)
       end
     }


### PR DESCRIPTION
### Summary

This Pull Request adds the Propshaft manifest file (`.manifest.json`) to the default value of `assets_manifests`. (Fix #257)

As mentioned in this comment (https://github.com/capistrano/rails/issues/257#issuecomment-1241051729), Propshaft support can be enabled by `adding assets_manifests` to the Capistrano configuration.
However, since Propshaft has become the default asset pipeline in Rails 8.0, I believe it makes sense to include it as a default value in 	`capistrano-rails`.

- Rails 8.0: Propshaft as the default asset pipeline
  - https://github.com/rails/rails/pull/51799

### Other Information

Note that the default manifest file for Propshaft is `public/assets/.manifest.json`, which is static path.
https://github.com/rails/propshaft/tree/main?tab=readme-ov-file#usage
